### PR TITLE
Fix util.format to take substitution parameters as an array passed as…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-localize",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "A simple context wrapper and text localization component for localizing strings",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/util.format.js
+++ b/src/util.format.js
@@ -8,6 +8,8 @@ function format(fmt) {
   var re = /(%?)(%([jds]))/g
     , args = Array.prototype.slice.call(arguments, 1);
   if(args.length) {
+    if(Array.isArray(args[0]))
+        args = args[0];
     fmt = fmt.replace(re, function(match, escaped, ptn, flag) {
       var arg = args.shift();
       switch(flag) {

--- a/src/util.format.test.js
+++ b/src/util.format.test.js
@@ -13,8 +13,19 @@ test('formats a string properly when values are provided', () => {
   const numberFormatted = format('%d items in cart', [5]);
   expect(numberFormatted).toBe('5 items in cart');
 
-  const jsonFormatted = format('Source Codez: %j', [{ source: 'code' }]);
+  const jsonFormatted = format('Source Codez: %j', [ [{ source: 'code' }] ]);
   expect(jsonFormatted).toBe('Source Codez: [{\"source\":\"code\"}]');
+});
+
+test('also works with multiple values', () => {
+  const formatted = format('Hello, %s %s', ['Stephen', 'Myers']);
+  expect(formatted).toBe('Hello, Stephen Myers');
+
+  const numberFormatted = format('%d of %d items in cart', [5, 10]);
+  expect(numberFormatted).toBe('5 of 10 items in cart');
+
+  const jsonFormatted = format('Source Codez: %j %j', [ [{ source: 'code' }], { id: 'object identifier' } ]);
+  expect(jsonFormatted).toBe('Source Codez: [{\"source\":\"code\"}] {\"id\":\"object identifier\"}');
 });
 
 test('does not explode when a message is missing', () => {


### PR DESCRIPTION
… second argument to make default localize function work with more than one substitution per string.